### PR TITLE
AD-245600: Remove maxConcurrentCalls setting in host.json

### DIFF
--- a/NCS.DSS.GDPRUpdateCustomerInformation/Services/SqlDbService.cs
+++ b/NCS.DSS.GDPRUpdateCustomerInformation/Services/SqlDbService.cs
@@ -145,10 +145,10 @@ namespace NCS.DSS.DataUtility.Services
             {
                 string executionQuery =
                     // master data table
-                    @"DELETE FROM [dss-" + @tableName + "] WHERE id=@recordId;" +
+                    @"DELETE FROM [dss-" + @tableName + "] WHERE id=@recordId OPTION (MAXDOP 1);" +
 
                      // history table
-                     "DELETE FROM [dss-" + @tableName + "-history] WHERE id=@recordId;";
+                     "DELETE FROM [dss-" + @tableName + "-history] WHERE id=@recordId OPTION (MAXDOP 1);";
 
                 connection.Open();
 

--- a/NCS.DSS.GDPRUpdateCustomerInformation/host.json
+++ b/NCS.DSS.GDPRUpdateCustomerInformation/host.json
@@ -8,12 +8,5 @@
             },
             "enableLiveMetricsFilters": true
         }
-    },
-    "extensions": {
-      "serviceBus": {
-        "messageHandlerOptions": {
-          "maxConcurrentCalls": 2
-        }
-      }
     }
 }


### PR DESCRIPTION
This pull request makes a small configuration change to the `host.json` file, specifically removing the `serviceBus` extension settings. This means that the `maxConcurrentCalls` option for Service Bus message handling is no longer explicitly set, and the default configuration will be used instead.